### PR TITLE
Update service.pp

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -55,7 +55,22 @@ class nexus::service (
       enable => true,
     }
 
-  } else {
+  } elsif ($::operatingsystem == 'RedHat') or ($::operatingsystem == 'CentOS') {
+      file { '/etc/systemd/system/nexus.service':
+      mode    => '0644',
+      owner   => 'root',
+      group   => 'root',
+      content => template('nexus/nexus.systemd.erb'),
+    } ->
+    service { 'nexus':
+      ensure => running,
+      name   => 'nexus',
+      enable => true,
+    }
+  }
+  
+  
+    else {
 
     file_line{ 'nexus_NEXUS_HOME':
       path  => $nexus_script,


### PR DESCRIPTION
Add RHEL/CentOS systemd service handling.
For now if Nexus is stopped on RHEL/CentOS, puppet agent sync can't start it. These changes fix this behaviour.
